### PR TITLE
fix <back> <user, setPongUsername>: fix to disable duplicates

### DIFF
--- a/backend/src/user/user.entity.ts
+++ b/backend/src/user/user.entity.ts
@@ -22,7 +22,7 @@ export class User extends BaseEntity {
   @Column({ length: 128, unique: true })
   login42: string;
 
-  @Column({ nullable: true })
+  @Column({ nullable: true, unique: true })
   pongUsername: string;
 
   @Column({ length: 128, unique: true })

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -59,13 +59,6 @@ export class UsersService {
     return user;
   }
 
-  async getByPongUsername(inputPongUsername: string): Promise<User> {
-    const user = await this.usersRepository.findOneBy({
-      pongUsername: inputPongUsername,
-    });
-    return user;
-  }
-
   getFrontUsername(user: User) {
     if (!user.pongUsername) return user.login42;
     return user.pongUsername;
@@ -298,17 +291,15 @@ export class UsersService {
 
   async setPongUsername(dto: pongUsernameDto, login42: string) {
     const user = await this.findOne(login42);
-    const isPongUsernameTaken = await this.getByPongUsername(
-      dto.newPongUsername,
-    );
-
-    if (isPongUsernameTaken)
-      throw new BadRequestException({ error: 'Nickname already taken' });
 
     /* We use TypeORM's update function to update our entity */
-    await this.usersRepository.update(user.id, {
-      pongUsername: dto.newPongUsername,
-    });
+    try {
+      await this.usersRepository.update(user.id, {
+        pongUsername: dto.newPongUsername,
+      });
+    } catch (e) {
+      throw new BadRequestException({ error: 'Nickname already taken' });
+    }
   }
 
   async getPicture(dto: User) {


### PR DESCRIPTION
We now throw a Bad Request error when a user tries to set a nickname already taken by someone else.