### PR TITLE
Hotfix <back> <createRoom>: client joins a channel when creating it

### DIFF
--- a/backend/shared/interfaces/UserId.ts
+++ b/backend/shared/interfaces/UserId.ts
@@ -1,3 +1,0 @@
-export default interface UserId {
-  id: number;
-}


### PR DESCRIPTION
Fixed a bug where client didn't automatically join rooms when creating a channel.