### PR TITLE
fix : Unstable state with colors front/back

### DIFF
--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -34,10 +34,10 @@ function App() {
   const [currentUser, setCurrentUser] = useState<CurrentUserFrontInterface>(
     createCurrentUserFrontInterface()
   );
-  const setColors = (setRightColor: (colors: GameColors) => GameColors) => {
+  const setColors = (newColors: GameColors) => {
     setCurrentUser((current: CurrentUserFrontInterface) => {
       let newCurrentUser = { ...current };
-      newCurrentUser.gameColors = setRightColor(newCurrentUser.gameColors);
+      newCurrentUser.gameColors = newColors;
       return newCurrentUser;
     });
   };

--- a/frontend/src/components/NavBar/Pages-To-Change/Play.tsx
+++ b/frontend/src/components/NavBar/Pages-To-Change/Play.tsx
@@ -11,6 +11,7 @@ import { GameColors, defaultColor } from "/shared/types/GameColors";
 import { GameStep } from "/src/components/PongGame/GameStep.enum";
 import GameSettings from "../../PongGame/GameSettings";
 import { HexColorPicker } from "react-colorful";
+import toast from "react-hot-toast";
 
 type PlayProps = {
   socket: Socket | undefined;
@@ -20,6 +21,10 @@ type PlayProps = {
 
 const Play: React.FC<PlayProps> = ({ socket, colors, setColors }) => {
   const [step, setStep] = useState<number>(0);
+  const [localColors, setLocalColors] = useState<GameColors>(colors);
+  useEffect(() => {
+    setLocalColors(colors);
+  }, [colors]);
   /** WEBSOCKET */
   const [gameRoom, setGameRoom] = useState<GameRoom | undefined>(undefined);
   const [clientCanvasSize, setClientCanvasSize] = useState<Position>({
@@ -57,21 +62,25 @@ const Play: React.FC<PlayProps> = ({ socket, colors, setColors }) => {
   };
 
   const setRightColor = (key: string) => (newColor: string) => {
-    setColors((current: GameColors) => {
-      current[key as keyof GameColors] = newColor;
-      return current;
+    setLocalColors((current: GameColors) => {
+      let newColors = { ...current };
+      newColors[key as keyof GameColors] = newColor;
+      return newColors;
     });
   };
 
   const setDefaultColors = () => {
-    setColors((current: GameColors) => {
-      return { ...defaultColor };
-    });
+    setLocalColors({ ...defaultColor });
+    toast.success("Color reset");
   };
 
   const gameSteps = [
     <GameLobby socket={socket} setStep={setStep} setGameRoom={setGameRoom} />,
-    <GameSettings setStep={setStep} colors={colors} />,
+    <GameSettings
+      setStep={setStep}
+      colors={localColors}
+      setColors={setColors}
+    />,
     <GameQueue
       socket={socket}
       setStep={setStep}
@@ -98,12 +107,12 @@ const Play: React.FC<PlayProps> = ({ socket, colors, setColors }) => {
       {step === GameStep["SETTINGS"] ? (
         <div>
           <div className="grid grid-cols-3 gap-4">
-            {Object.keys(colors).map((key) => {
+            {Object.keys(localColors).map((key) => {
               return (
                 <div key={key}>
                   {key}
                   <HexColorPicker
-                    color={colors[key as keyof GameColors]}
+                    color={localColors[key as keyof GameColors]}
                     onChange={setRightColor(key)}
                   />
                 </div>

--- a/frontend/src/components/PongGame/GameCanvas.tsx
+++ b/frontend/src/components/PongGame/GameCanvas.tsx
@@ -137,7 +137,6 @@ const GameCanvas: React.FC<GameCanvasProps> = ({
   };
 
   useEffect(() => {
-    console.log(colors.ball, colors.paddle, colors.background);
     socket?.on(ROUTES_BASE.GAME.UPDATE_GAME, handleGameUpdate);
     return () => {
       socket?.off(ROUTES_BASE.GAME.UPDATE_GAME, handleGameUpdate);

--- a/frontend/src/components/PongGame/GameSettings.tsx
+++ b/frontend/src/components/PongGame/GameSettings.tsx
@@ -1,17 +1,26 @@
-import React from "react";
+import React, { Dispatch, SetStateAction } from "react";
 import { GameStep } from "/src/components/PongGame/GameStep.enum";
 import { GameColors } from "/shared/types/GameColors";
 import { Api } from "../../api/api";
+import toast from "react-hot-toast";
 const api = new Api();
 type GameSettingsProps = {
   setStep: any;
   colors: GameColors;
+  setColors: Dispatch<SetStateAction<GameColors>>;
 };
 
-const GameSettings: React.FC<GameSettingsProps> = ({ setStep, colors }) => {
+const GameSettings: React.FC<GameSettingsProps> = ({
+  setStep,
+  colors,
+  setColors,
+}) => {
   const redirectToLobby = () => {
     setStep(GameStep.LOBBY);
-    api.set_game_colors(colors);
+    api.set_game_colors(colors).then((res: Response) => {
+      if (res.status == 201) setColors(colors);
+      else toast.error("Your changes couldn't be validated, an error occured");
+    });
   };
 
   return (
@@ -20,7 +29,7 @@ const GameSettings: React.FC<GameSettingsProps> = ({ setStep, colors }) => {
         className="bg-sky-500 hover:bg-sky-700 text-xl rounded-2xl p-4 shadow-md shadow-blue-500/50 max-w-xs place-self-center"
         onClick={redirectToLobby}
       >
-        Back to Game Lobby
+        Back to Game Lobby and save changes
       </button>
     </div>
   );


### PR DESCRIPTION
There was an issue I kind of wanted to let under the rug... But, I was afraid it could cost us haha

There wasn't any "validation" step, that was front and back efficient.
Go back to game lobby was saving the changes on back, (if success obviously), but, front wouldn't care less if any validation occured. Now, both front and back agree on colors whatever happen.